### PR TITLE
Expose peer connection count as 'conns'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ The return value is an array-like Lua table for all the primary peers. Each tabl
 * checked
 
     Timestamp for the last check (in seconds since the Epoch)
+* conns
+
+    Number of active connections to the peer.
 
 [Back to TOC](#table-of-contents)
 

--- a/src/ngx_http_lua_upstream_module.c
+++ b/src/ngx_http_lua_upstream_module.c
@@ -438,6 +438,10 @@ ngx_http_lua_get_peer(lua_State *L, ngx_http_upstream_rr_peer_t *peer,
     lua_pushinteger(L, (lua_Integer) peer->effective_weight);
     lua_rawset(L, -3);
 
+    lua_pushliteral(L, "conns");
+    lua_pushinteger(L, (lua_Integer) peer->conns);
+    lua_rawset(L, -3);
+
     lua_pushliteral(L, "fails");
     lua_pushinteger(L, (lua_Integer) peer->fails);
     lua_rawset(L, -3);

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -227,7 +227,7 @@ upstream bar:
 --- request
     GET /t
 --- response_body_like chop
-^\[\{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"\d{1,3}(?:\.\d{1,3}){3}:80","weight":1\}(?:,\{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":\d+,"max_fails":1,"name":"\d{1,3}(?:\.\d{1,3}){3}:80","weight":1\})+\]$
+^\[\{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"\d{1,3}(?:\.\d{1,3}){3}:80","weight":1\}(?:,\{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":\d+,"max_fails":1,"name":"\d{1,3}(?:\.\d{1,3}){3}:80","weight":1\})+\]$
 
 --- no_error_log
 [error]
@@ -267,8 +267,8 @@ upstream bar:
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"effective_weight":4,"fail_timeout":53,"fails":0,"id":0,"max_fails":100,"name":"127.0.0.1:80","weight":4},{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":1,"max_fails":1,"name":"106.184.1.99:81","weight":1}]
-[{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.2:80","weight":1}]
+[{"conns":0,"current_weight":0,"effective_weight":4,"fail_timeout":53,"fails":0,"id":0,"max_fails":100,"name":"127.0.0.1:80","weight":4},{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":1,"max_fails":1,"name":"106.184.1.99:81","weight":1}]
+[{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.2:80","weight":1}]
 --- no_error_log
 [error]
 
@@ -307,8 +307,8 @@ upstream bar:
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"effective_weight":1,"fail_timeout":5,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.6:80","weight":1}]
-[{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
+[{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":5,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.6:80","weight":1}]
+[{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"conns":0,"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
 --- no_error_log
 [error]
 
@@ -344,7 +344,7 @@ upstream bar:
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"down":true,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.2:80","weight":1}]
+[{"conns":0,"current_weight":0,"down":true,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.2:80","weight":1}]
 --- no_error_log
 [error]
 
@@ -416,7 +416,7 @@ failed to set peer down: bad peer id
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"down":true,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
+[{"conns":0,"current_weight":0,"down":true,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"conns":0,"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
 --- no_error_log
 [error]
 
@@ -458,7 +458,7 @@ failed to set peer down: bad peer id
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
+[{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"conns":0,"current_weight":0,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
 --- no_error_log
 [error]
 
@@ -495,7 +495,7 @@ failed to set peer down: bad peer id
 --- request
     GET /t
 --- response_body
-[{"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"current_weight":0,"down":true,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
+[{"conns":0,"current_weight":0,"effective_weight":1,"fail_timeout":10,"fails":0,"id":0,"max_fails":1,"name":"127.0.0.3:80","weight":1},{"conns":0,"current_weight":0,"down":true,"effective_weight":7,"fail_timeout":23,"fails":0,"id":1,"max_fails":200,"name":"127.0.0.4:80","weight":7}]
 --- no_error_log
 [error]
 


### PR DESCRIPTION
We would like to use this data in Lua for various load-balancing purposes.

Note: this includes the commit from #18 so my tests will pass – if that PR is merged first then this PR will automatically exclude the commit.

If there is a good way to hold a connection open with this testing framework, I can add a test explicitly asserting the value works when there are active connections. I don't think it's necessary, since the compilation success combined with the passing of existing tests indicates the `peers` field in `ngx_http_upstream_rr_peer_t` is being referred to correctly.