### PR TITLE
Fix lua_createtable size in ngx_http_lua_get_peer

### DIFF
--- a/src/ngx_http_lua_upstream_module.c
+++ b/src/ngx_http_lua_upstream_module.c
@@ -404,6 +404,10 @@ ngx_http_lua_get_peer(lua_State *L, ngx_http_upstream_rr_peer_t *peer,
 
     n = 8;
 
+#if (nginx_version >= 1009000)
+    n++;
+#endif
+
     if (peer->down) {
         n++;
     }


### PR DESCRIPTION
This corrects the size parameter passed to `lua_createtable` in `ngx_http_lua_get_peer` to account for the `conns` element when `nginx_version >= 1009000`.
