### PR TITLE
Added missing doc for "down" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ The return value is an array-like Lua table for all the primary peers. Each tabl
 * checked
 
     Timestamp for the last check (in seconds since the Epoch)
+* down
+
+    Holds true if the peer has been marked as "down", otherwise this key is not present
 * conns
 
     Number of active connections to the peer (this requires NGINX 1.9.0 or above).


### PR DESCRIPTION
The readme part documenting the format of data returned by get_primary_peers()/get_backup_peers() was missing info for the "down" key (which is quite important imho).

Dunno if this info is not present there on purpose (close this PR in that case), otherwise - this adds that field to the doc