### PR TITLE
fix set_peer_down

### DIFF
--- a/src/ngx_http_lua_upstream_module.c
+++ b/src/ngx_http_lua_upstream_module.c
@@ -348,6 +348,12 @@ ngx_http_lua_upstream_set_peer_down(lua_State * L)
 
     peer->down = lua_toboolean(L, 4);
 
+    /* mark peer live if turned up */
+
+    if (!peer->down) {
+        peer->fails = 0;
+    }
+
     lua_pushboolean(L, 1);
     return 1;
 }


### PR DESCRIPTION
@agentzh hi， this pull request fix set_peer_down, mark peer live if turned up.
when peer->down = 0,but peer->fails >= peer->max_fails, this peer still disable,  so need to set peer->fails = 0