### PR TITLE
doc: fixed description of get_upstreams()

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ get_upstreams
 
 Get a list of the names for all the named upstream groups (i.e., explicit `upstream {}` blocks).
 
-Note that implicit upstream groups created by `proxy_pass` and etc are excluded.
+Note that implicit upstream groups created by `proxy_pass` and etc are included.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
get_upstreams() actually include implicit upstream created by proxy_pass, but doc said that was excluded.